### PR TITLE
Dodanie frameworku automatycznych testów akceptacyjnych

### DIFF
--- a/openpkw-test/pom.xml
+++ b/openpkw-test/pom.xml
@@ -48,6 +48,14 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>**/When*.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/openpkw-test/pom.xml
+++ b/openpkw-test/pom.xml
@@ -37,4 +37,17 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.18.1</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/openpkw-test/src/test/java/org/openpkw/weryfikator/rest/When_sending_POST_request_to_test_url.java
+++ b/openpkw-test/src/test/java/org/openpkw/weryfikator/rest/When_sending_POST_request_to_test_url.java
@@ -17,7 +17,7 @@ public class When_sending_POST_request_to_test_url {
         String testContent = "{\"test\":\"OpenPKW rules\"}";
 
         Client client = ClientBuilder.newClient();
-        WebTarget target = client.target("http://localhost:8080/openpkw/test/echo");
+        WebTarget target = client.target("http://dobrogmir.openpkw.pl:9080/openpkw/test/echo");
         String response = target.request().post(Entity.json(testContent), String.class);
 
         assertThat(response, equalTo(testContent));

--- a/openpkw-test/src/test/java/org/openpkw/weryfikator/rest/When_sending_POST_request_to_test_url.java
+++ b/openpkw-test/src/test/java/org/openpkw/weryfikator/rest/When_sending_POST_request_to_test_url.java
@@ -17,7 +17,7 @@ public class When_sending_POST_request_to_test_url {
         String testContent = "{\"test\":\"OpenPKW rules\"}";
 
         Client client = ClientBuilder.newClient();
-        WebTarget target = client.target("http://dobrogmir.openpkw.pl:9080/openpkw/test/echo");
+        WebTarget target = client.target("http://dobromir.openpkw.pl:9080/openpkw/test/echo");
         String response = target.request().post(Entity.json(testContent), String.class);
 
         assertThat(response, equalTo(testContent));

--- a/openpkw-test/src/test/java/org/openpkw/weryfikator/rest/When_senging_GET_request_to_root_url.java
+++ b/openpkw-test/src/test/java/org/openpkw/weryfikator/rest/When_senging_GET_request_to_root_url.java
@@ -15,7 +15,7 @@ public class When_senging_GET_request_to_root_url {
     public void should_return_Hello_World_HTML_page() {
 
         Client client = ClientBuilder.newClient();
-        WebTarget target = client.target("http://localhost:8080/openpkw/");
+        WebTarget target = client.target("http://dobromir.openpkw.pl:9080/openpkw/");
         String response = target.request().get(String.class);
 
         assertThat(response, containsString("Hello World"));

--- a/pom.xml
+++ b/pom.xml
@@ -42,22 +42,52 @@
                 <wildfly.management.host>localhost</wildfly.management.host>
                 <wildfly.management.port>9999</wildfly.management.port>
                 <wildfly.management.user>jenkins</wildfly.management.user>
-                <wildfly.management.password />
+                <wildfly.management.password></wildfly.management.password>
             </properties>
         </profile>
         <profile>
-            <id>DEV</id>
+            <id>VAGRANT</id>
             <activation>
                 <property>
                     <name>openpkw-env</name>
-                    <value>dev</value>
+                    <value>vagrant</value>
+                </property>
+            </activation>
+            <properties>
+                <wildfly.management.host>localhost</wildfly.management.host>
+                <wildfly.management.port>4502</wildfly.management.port>
+                <wildfly.management.user>jenkins</wildfly.management.user>
+                <wildfly.management.password></wildfly.management.password>
+            </properties>
+        </profile>
+        <profile>
+            <id>TEST</id>
+            <activation>
+                <property>
+                    <name>openpkw-env</name>
+                    <value>test</value>
                 </property>
             </activation>
             <properties>
                 <wildfly.management.host>dobromir.openpkw.pl</wildfly.management.host>
                 <wildfly.management.port>9999</wildfly.management.port>
                 <wildfly.management.user>jenkins</wildfly.management.user>
-                <wildfly.management.password />
+                <wildfly.management.password></wildfly.management.password>
+            </properties>
+        </profile>
+        <profile>
+            <id>UAT</id>
+            <activation>
+                <property>
+                    <name>openpkw-env</name>
+                    <value>uat</value>
+                </property>
+            </activation>
+            <properties>
+                <wildfly.management.host>pat.openpkw.pl</wildfly.management.host>
+                <wildfly.management.port>9999</wildfly.management.port>
+                <wildfly.management.user>jenkins</wildfly.management.user>
+                <wildfly.management.password></wildfly.management.password>
             </properties>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.openpkw</groupId>
     <artifactId>openpkw</artifactId>
@@ -12,8 +13,8 @@
         <module>openpkw-etc</module>
         <module>openpkw-test</module>
         <module>openpkw-utils</module>
-    <module>openpkw-utils-csv</module>
-  </modules>
+        <module>openpkw-utils-csv</module>
+    </modules>
     <packaging>pom</packaging>
     <name>openpkw</name>
 
@@ -41,7 +42,7 @@
                 <wildfly.management.host>localhost</wildfly.management.host>
                 <wildfly.management.port>9999</wildfly.management.port>
                 <wildfly.management.user>jenkins</wildfly.management.user>
-                <wildfly.management.password/>
+                <wildfly.management.password />
             </properties>
         </profile>
         <profile>
@@ -56,7 +57,7 @@
                 <wildfly.management.host>dobromir.openpkw.pl</wildfly.management.host>
                 <wildfly.management.port>9999</wildfly.management.port>
                 <wildfly.management.user>jenkins</wildfly.management.user>
-                <wildfly.management.password/>
+                <wildfly.management.password />
             </properties>
         </profile>
     </profiles>
@@ -253,6 +254,24 @@
                 </configuration>
             </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>2.19</version>
+                    <executions>
+                        <execution>
+                            <id>integration-test</id>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <pluginRepositories>


### PR DESCRIPTION
Proponowana zmiana polega na dodaniu trzeciego kroku do pipeline'a Continuous Delivery. Krok ten polegać będzie na uruchomieniu automatycznych testów akceptacyjnych na środowisku DEV (czyli na Dobromirze).

Czyli cały pipeline będzie wyglądać tak:
Trigger: Każda zmiana kodu na repozytorium "master".
1. Kompilacja, uruchomienie unit testów i zbudowanie pakietów.
2. Deployment na Dobromira.
3. Uruchomienie testów akceptacyjnych.

Testy akceptacyjne znajdują się w projekcie openpkw-test. Na razie są tam dwa bardzo, bardzo, bardzo prymitywne testy web serwisu restowego. Uruchamiane są przy pomocy plugina FailSafe.