### PR TITLE
OW-U-21: Łączenie się z backendem poprzez proxy, zamiast przez CORS

### DIFF
--- a/openpkw-rest/src/main/java/org/openpkw/web/controllers/DistrictsController.java
+++ b/openpkw-rest/src/main/java/org/openpkw/web/controllers/DistrictsController.java
@@ -1,16 +1,15 @@
 package org.openpkw.web.controllers;
 
+import javax.inject.Inject;
+
 import org.openpkw.services.rest.dto.DistrictsDTO;
 import org.openpkw.services.rest.services.RESTService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.inject.Inject;
 
 /**
  * @author SzestKam (Kamil Szestowicki) 
@@ -23,16 +22,15 @@ public class DistrictsController {
     @Inject
     RESTService restService;
 
-    //zwraca listę wszystkich okręgów
+    /**
+     * Zwraca listę wszystkich okręgów
+     */
     @RequestMapping("/districts")
     public ResponseEntity<DistrictsDTO> getDistricts() {
         ResponseEntity<DistrictsDTO> result;
 
         try {
-            HttpHeaders htppHeaders = new HttpHeaders();
-            htppHeaders.add("Access-Control-Allow-Origin", "*");
-            htppHeaders.add("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT");
-            result = new ResponseEntity<>(restService.getDistricts(), htppHeaders,HttpStatus.OK);
+            result = new ResponseEntity<>(restService.getDistricts(), HttpStatus.OK);
         } catch (NullPointerException nex) {
             String errorMsg = "Can't get districts [NullPointerException]";
             LOGGER.warn(errorMsg, nex);
@@ -40,5 +38,4 @@ public class DistrictsController {
         }
         return result;
     }
-    
 }

--- a/openpkw-rest/src/main/java/org/openpkw/web/controllers/VotesController.java
+++ b/openpkw-rest/src/main/java/org/openpkw/web/controllers/VotesController.java
@@ -1,21 +1,20 @@
 package org.openpkw.web.controllers;
 
+import javax.inject.Inject;
+
 import org.openpkw.services.rest.dto.AllVotesAnswerDTO;
 import org.openpkw.services.rest.services.RESTService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.http.ResponseEntity;
-
-import javax.inject.Inject;
 
 /**
  * REST Web Service
  *
- * @author kamil
+ * @author Kamil Szestowicki
  */
 @RestController
 public class VotesController {
@@ -29,10 +28,7 @@ public class VotesController {
     public ResponseEntity<AllVotesAnswerDTO> getJson() {
         ResponseEntity<AllVotesAnswerDTO> result;
         try {
-            HttpHeaders htppHeaders = new HttpHeaders();
-            htppHeaders.add("Access-Control-Allow-Origin", "*");
-            htppHeaders.add("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT");
-            result = new ResponseEntity<>(restService.getAllVotesAnswer(), htppHeaders, HttpStatus.OK);
+            result = new ResponseEntity<>(restService.getAllVotesAnswer(), HttpStatus.OK);
         } catch (NullPointerException nex) {
             String errorMsg = "Can't get votes [NullPointerException]";
             LOGGER.warn(errorMsg, nex);

--- a/openpkw-test/src/test/java/org/openpkw/weryfikator/rest/Configuration.java
+++ b/openpkw-test/src/test/java/org/openpkw/weryfikator/rest/Configuration.java
@@ -4,8 +4,13 @@ public class Configuration {
 
     public static final String TEST_SERVER_ADDRESS = "targetServerAddress";
 
-
     public static String getHost() {
-        return System.getProperty(TEST_SERVER_ADDRESS);
+        String testServerAddress = System.getProperty(TEST_SERVER_ADDRESS);
+
+        if (testServerAddress == null || testServerAddress.trim().length() == 0) {
+            throw new RuntimeException("Test server address is not configured. End-to-end have to be run against a running instance of OpenPKW Weryfikator. Provide address of the server in " + TEST_SERVER_ADDRESS + " property.");
+        }
+
+        return testServerAddress;
     }
 }


### PR DESCRIPTION
Zmiany obejmują trzy projekty:
- openpkw-devops
- openpkw-weryfikator-frontend
- openpkw-weryfikator-backend

W projekcie openpkw-weryfikator są dwie zmiany:
1. Usunięcie nagłówków CORS z odpowiedzi web serwisu.
2. Poprawka ułatwiająca testowanie: jeśli nie jest podany serwer, względem którego odpalane mają być testy end-to-end, rzucony zostanie wyjątek z komunikatem opisującym problem.